### PR TITLE
Implement sandboxed router browser

### DIFF
--- a/public/proxy-sw.js
+++ b/public/proxy-sw.js
@@ -28,14 +28,34 @@ function b64url(s) {
   return enc.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
+function fromBase64Url(value) {
+  const padLength = (4 - (value.length % 4 || 4)) % 4;
+  const padded = value + '='.repeat(padLength);
+  const base64 = padded.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 self.addEventListener('fetch', (event) => {
   const req = event.request;
   const url = new URL(req.url);
   const wb = self.__WORKER_BASE;
   if (!wb) return; // nothing to rewrite without base
 
-  if (url.origin === location.origin && (url.pathname === '/p' || url.pathname === '/fetch')) {
+  const isAppOrigin = url.origin === location.origin;
+  if (!isAppOrigin) return;
+
+  if (url.pathname === '/p' || url.pathname === '/fetch' || url.pathname === '/dispatch') {
     event.respondWith(handleProxy(req));
+    return;
+  }
+
+  if (url.pathname.startsWith('/__sandbox__/asset/')) {
+    event.respondWith(handleSandboxAsset(req));
   }
 
   async function handleProxy(origReq) {
@@ -51,21 +71,86 @@ self.addEventListener('fetch', (event) => {
       credentials: 'omit'
     };
     const res = await fetch(outUrl, init);
-    const xsc = res.headers.get('X-Set-Cookie');
-    let sid = '';
-    if (inUrl.pathname === '/p') sid = new URLSearchParams(inUrl.search).get('sid') || '';
-    if (inUrl.pathname === '/fetch') {
-      try {
-        const body = await origReq.clone().text();
-        const parsed = JSON.parse(body);
-        sid = parsed && parsed.sid || '';
-      } catch {}
+    const sid = await extractSidFromRequest(inUrl, origReq);
+    if (sid) {
+      const header = collectXSetCookie(res.headers);
+      if (header) {
+        const all = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+        all.forEach(c => c.postMessage({ type: 'set-cookie', sid, header }));
+      }
     }
-    if (xsc) {
-      const all = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
-      all.forEach(c => c.postMessage({ type: 'set-cookie', sid, header: xsc }));
+    return res;
+  }
+
+  async function handleSandboxAsset(origReq) {
+    const info = decodeSandboxAssetUrl(new URL(origReq.url));
+    if (!info) {
+      return new Response('Bad sandbox asset request', { status: 400 });
+    }
+    const target = info.target;
+    const sid = info.sid;
+    const proxied = `${wb}/p?sid=${encodeURIComponent(sid)}&u=${encodeURIComponent(b64url(target))}`;
+    const init = {
+      method: origReq.method,
+      headers: new Headers(origReq.headers),
+      body: origReq.method !== 'GET' && origReq.method !== 'HEAD' ? await origReq.clone().arrayBuffer() : undefined,
+      mode: 'cors',
+      cache: 'no-cache',
+      redirect: 'follow',
+      credentials: 'omit'
+    };
+    const res = await fetch(proxied, init);
+    if (sid) {
+      const header = collectXSetCookie(res.headers);
+      if (header) {
+        const all = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+        all.forEach(c => c.postMessage({ type: 'set-cookie', sid, header }));
+      }
     }
     return res;
   }
 });
+
+function collectXSetCookie(headers) {
+  const collected = [];
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'x-set-cookie' && value) {
+      collected.push(value);
+    }
+  });
+  if (!collected.length) return null;
+  return collected.join(',');
+}
+
+async function extractSidFromRequest(url, req) {
+  if (url.pathname === '/p') {
+    return new URLSearchParams(url.search).get('sid') || '';
+  }
+  if (url.pathname === '/fetch' || url.pathname === '/dispatch') {
+    try {
+      const body = await req.clone().text();
+      const parsed = JSON.parse(body);
+      return parsed && parsed.sid || '';
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+function decodeSandboxAssetUrl(url) {
+  const prefix = '/__sandbox__/asset/';
+  if (!url.pathname.startsWith(prefix)) return null;
+  const remainder = url.pathname.slice(prefix.length);
+  const parts = remainder.split('/').filter(Boolean);
+  if (parts.length < 3) return null;
+  const [sidEncoded, scheme, hostEncoded, ...pathParts] = parts;
+  const sid = decodeURIComponent(sidEncoded);
+  if (scheme !== 'https') return null;
+  const host = decodeURIComponent(hostEncoded);
+  const path = pathParts.length ? `/${pathParts.map(decodeURIComponent).join('/')}` : '/';
+  const qs = url.searchParams.get('__qs');
+  const query = qs ? `?${fromBase64Url(qs)}` : '';
+  return { sid, target: `https://${host}${path}${query}` };
+}
 

--- a/public/proxy-sw.js
+++ b/public/proxy-sw.js
@@ -18,7 +18,8 @@ self.addEventListener('message', (event) => {
   if (data.type === 'warmup') {
     const wb = self.__WORKER_BASE;
     if (wb) {
-      event.waitUntil(fetch(wb + '/p?sid=_warm&u=' + encodeURIComponent(b64url('https://example.com'))).catch(() => undefined));
+      const warmUrl = wb.endsWith('/') ? wb : `${wb}/`;
+      event.waitUntil(fetch(warmUrl, { method: 'GET', mode: 'no-cors', cache: 'no-store' }).catch(() => undefined));
     }
   }
 });

--- a/src/app/CookieStore.ts
+++ b/src/app/CookieStore.ts
@@ -1,6 +1,11 @@
+type CookieRecord = {
+  raw: string;
+  lastSeen: string;
+};
+
 export class CookieStore {
   private key: string;
-  private jar: Record<string, string> = {};
+  private jar: Record<string, CookieRecord> = {};
 
   constructor(sessionId: string) {
     this.key = `cookies:${sessionId}`;
@@ -9,28 +14,43 @@ export class CookieStore {
 
   applyFromHeader(xSetCookie: string | null | undefined) {
     if (!xSetCookie) return;
-    // X-Set-Cookie is URL-encoded by the Worker; decode and store raw for display.
-    try {
-      const decoded = decodeURIComponent(xSetCookie);
-      // Very naive: store under a synthetic host bucket
-      const now = new Date().toISOString();
-      this.jar[now] = decoded;
-      this.save();
-    } catch {
-      // ignore parse errors
+    const chunks = xSetCookie.split(',');
+    const now = new Date().toISOString();
+    for (const chunk of chunks) {
+      const trimmed = chunk.trim();
+      if (!trimmed) continue;
+      try {
+        const decoded = decodeURIComponent(trimmed);
+        const [namePart] = decoded.split(';', 1);
+        const [cookieName] = namePart?.split('=', 1) ?? [];
+        if (cookieName) {
+          this.jar[cookieName.trim()] = { raw: decoded, lastSeen: now };
+        }
+      } catch {
+        // ignore parse errors per cookie
+      }
     }
+    this.save();
   }
 
   getDisplay(host?: string): string[] {
-    const entries = Object.entries(this.jar);
+    void host; // host filtering not implemented but kept for API shape
+    const entries = Object.values(this.jar);
     if (!entries.length) return [];
-    return entries.map(([k, v]) => `${k}: ${v}`);
+    return entries
+      .sort((a, b) => (a.lastSeen < b.lastSeen ? 1 : -1))
+      .map(entry => `${entry.lastSeen} — ${entry.raw}`);
   }
 
   load() {
     try {
       const raw = localStorage.getItem(this.key);
-      if (raw) this.jar = JSON.parse(raw);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+          this.jar = parsed as Record<string, CookieRecord>;
+        }
+      }
     } catch {
       this.jar = {};
     }

--- a/src/app/UrlHistory.ts
+++ b/src/app/UrlHistory.ts
@@ -21,5 +21,16 @@ export class UrlHistory {
     if (this.idx < this.list.length - 1) this.idx++;
     return this.list[this.idx] ?? '';
   }
+
+  current(): string {
+    return this.list[this.idx] ?? '';
+  }
+
+  replace(url: string) {
+    if (!url) return;
+    if (this.idx >= 0 && this.idx < this.list.length) {
+      this.list[this.idx] = url;
+    }
+  }
 }
 

--- a/src/app/sandboxDom.ts
+++ b/src/app/sandboxDom.ts
@@ -1,0 +1,259 @@
+export type PreparedDocument = {
+  html: string;
+  title?: string;
+};
+
+export type PrepareOptions = {
+  baseUrl: string;
+  sandboxId: string;
+  frameId: string;
+};
+
+const disallowedSchemes = ['javascript:', 'data:', 'mailto:', 'tel:'];
+
+export function toBase64Url(input: string): string {
+  const encoded = btoa(unescape(encodeURIComponent(input)));
+  return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function decodeHtml(html: string): Document {
+  const parser = new DOMParser();
+  return parser.parseFromString(html, 'text/html');
+}
+
+function resolveAbsoluteUrl(ref: string | null, base: string): string | null {
+  if (!ref) return null;
+  const trimmed = ref.trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+  if (disallowedSchemes.some(prefix => lower.startsWith(prefix))) return null;
+  try {
+    const absolute = new URL(trimmed, base);
+    if (!absolute.protocol.startsWith('http')) return null;
+    return absolute.toString();
+  } catch {
+    return null;
+  }
+}
+
+function encodePathname(pathname: string): string {
+  const segments = pathname.split('/').map(segment => encodeURIComponent(segment));
+  let joined = segments.join('/');
+  if (!joined.startsWith('/')) {
+    joined = `/${joined}`;
+  }
+  if (joined === '') {
+    joined = '/';
+  }
+  return joined;
+}
+
+export function buildSandboxAssetUrl(sandboxId: string, targetUrl: string): string {
+  const url = new URL(targetUrl);
+  const scheme = url.protocol.replace(':', '');
+  const host = encodeURIComponent(url.host);
+  const path = encodePathname(url.pathname);
+  const qs = url.search ? `?__qs=${toBase64Url(url.search.slice(1))}` : '';
+  return `/__sandbox__/asset/${encodeURIComponent(sandboxId)}/${scheme}/${host}${path}${qs}`;
+}
+
+function rewriteSrcSet(value: string, base: string, sandboxId: string): string {
+  const candidates = value.split(',');
+  const rewritten: string[] = [];
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    const urlPart = parts.shift() ?? '';
+    const descriptor = parts.join(' ');
+    const absolute = resolveAbsoluteUrl(urlPart, base);
+    if (!absolute) {
+      rewritten.push(trimmed);
+      continue;
+    }
+    const proxied = buildSandboxAssetUrl(sandboxId, absolute);
+    rewritten.push(descriptor ? `${proxied} ${descriptor}` : proxied);
+  }
+  return rewritten.join(', ');
+}
+
+function injectControllerScript(doc: Document, frameId: string) {
+  const script = doc.createElement('script');
+  script.type = 'application/javascript';
+  script.textContent = `(() => {
+    const FRAME_ID = ${JSON.stringify(frameId)};
+    const toBase64Url = (input) => {
+      const encoded = btoa(unescape(encodeURIComponent(input)));
+      return encoded.replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '');
+    };
+    const post = (type, payload) => {
+      try {
+        parent.postMessage(Object.assign({ type, frameId: FRAME_ID }, payload || {}), '*');
+      } catch (err) {
+        console.warn('sandbox postMessage failed', err);
+      }
+    };
+    const nativeSubmit = HTMLFormElement.prototype.submit;
+    HTMLFormElement.prototype.submit = function () {
+      const evt = new Event('submit', { bubbles: true, cancelable: true });
+      if (!this.dispatchEvent(evt)) return;
+      nativeSubmit.call(this);
+    };
+    const originalOpen = window.open;
+    window.open = function (url, target, features) {
+      if (url == null) {
+        return originalOpen ? originalOpen.call(window, url, target, features) : null;
+      }
+      try {
+        const absolute = new URL(String(url), location.href).toString();
+        post('sandbox:navigate', { url: absolute, method: 'GET', openNew: true });
+      } catch (err) {
+        post('sandbox:notify', { level: 'error', message: 'Failed to open URL: ' + (err && err.message ? err.message : err) });
+      }
+      return null;
+    };
+    document.addEventListener('click', (event) => {
+      const target = event.target instanceof Element ? event.target.closest('a[data-proxy-target]') : null;
+      if (!target) return;
+      const href = target.getAttribute('data-proxy-target');
+      if (!href) return;
+      event.preventDefault();
+      event.stopPropagation();
+      post('sandbox:navigate', {
+        url: href,
+        method: 'GET',
+        openNew: target.getAttribute('data-proxy-open') === 'new'
+      });
+    }, true);
+    document.addEventListener('submit', (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) return;
+      const action = form.getAttribute('data-proxy-action');
+      if (!action) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const method = (form.getAttribute('data-proxy-method') || form.getAttribute('method') || 'GET').toUpperCase();
+      const enctype = (form.getAttribute('enctype') || 'application/x-www-form-urlencoded').toLowerCase();
+      const formData = new FormData(form);
+      if (method === 'GET') {
+        try {
+          const nextUrl = new URL(action);
+          const params = new URLSearchParams(nextUrl.search);
+          for (const [key, value] of formData.entries()) {
+            if (typeof value === 'string') params.append(key, value);
+          }
+          nextUrl.search = params.toString();
+          post('sandbox:navigate', { url: nextUrl.toString(), method: 'GET' });
+        } catch (err) {
+          post('sandbox:notify', { level: 'error', message: 'Failed to submit form: ' + (err && err.message ? err.message : err) });
+        }
+        return;
+      }
+      if (method === 'POST' && (enctype === 'application/x-www-form-urlencoded' || enctype === '')) {
+        const params = new URLSearchParams();
+        for (const [key, value] of formData.entries()) {
+          if (typeof value === 'string') params.append(key, value);
+        }
+        const body = params.toString();
+        post('sandbox:navigate', {
+          url: action,
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          bodyB64: toBase64Url(body)
+        });
+        return;
+      }
+      post('sandbox:notify', { level: 'error', message: 'Unsupported form encoding: ' + enctype });
+    }, true);
+  })();`;
+  doc.head?.insertBefore(script, doc.head.firstChild);
+}
+
+export function prepareSandboxDocument(html: string, options: PrepareOptions): PreparedDocument {
+  const doc = decodeHtml(html);
+  const { baseUrl, sandboxId, frameId } = options;
+
+  doc.querySelectorAll('base').forEach(el => el.remove());
+
+  const proxify = (value: string | null) => {
+    const absolute = resolveAbsoluteUrl(value, baseUrl);
+    if (!absolute) return null;
+    return buildSandboxAssetUrl(sandboxId, absolute);
+  };
+
+  const proxifyAttribute = (selector: string, attr: string) => {
+    doc.querySelectorAll<HTMLElement>(selector).forEach(element => {
+      const value = element.getAttribute(attr);
+      const proxied = proxify(value);
+      if (proxied) {
+        element.setAttribute(attr, proxied);
+      }
+    });
+  };
+
+  proxifyAttribute('img[src]', 'src');
+  doc.querySelectorAll('img[srcset]').forEach(img => {
+    const srcset = img.getAttribute('srcset');
+    if (!srcset) return;
+    img.setAttribute('srcset', rewriteSrcSet(srcset, baseUrl, sandboxId));
+  });
+  doc.querySelectorAll('source[srcset]').forEach(source => {
+    const srcset = source.getAttribute('srcset');
+    if (!srcset) return;
+    source.setAttribute('srcset', rewriteSrcSet(srcset, baseUrl, sandboxId));
+  });
+  proxifyAttribute('source[src]', 'src');
+  proxifyAttribute('video[poster]', 'poster');
+  proxifyAttribute('video[src]', 'src');
+  proxifyAttribute('audio[src]', 'src');
+  proxifyAttribute('track[src]', 'src');
+  proxifyAttribute('iframe[src]', 'src');
+  proxifyAttribute('embed[src]', 'src');
+  proxifyAttribute('object[data]', 'data');
+  proxifyAttribute('script[src]', 'src');
+  doc.querySelectorAll('script[integrity]').forEach(script => script.removeAttribute('integrity'));
+  doc.querySelectorAll('link[href]').forEach(link => {
+    const rel = (link.getAttribute('rel') || '').toLowerCase();
+    const shouldProxy = ['stylesheet', 'icon', 'preload', 'prefetch', 'apple-touch-icon', 'manifest', 'alternate'].some(token => rel.includes(token));
+    if (!shouldProxy) return;
+    const proxied = proxify(link.getAttribute('href'));
+    if (proxied) {
+      link.setAttribute('href', proxied);
+      link.removeAttribute('integrity');
+    }
+  });
+
+  doc.querySelectorAll('a[href]').forEach(anchor => {
+    const href = anchor.getAttribute('href');
+    if (!href) return;
+    if (href.startsWith('#')) return;
+    const absolute = resolveAbsoluteUrl(href, baseUrl);
+    if (!absolute) return;
+    anchor.setAttribute('data-proxy-target', absolute);
+    if (anchor.getAttribute('target') === '_blank') {
+      anchor.setAttribute('data-proxy-open', 'new');
+    }
+    anchor.setAttribute('href', '#');
+    anchor.setAttribute('rel', 'noreferrer noopener');
+  });
+
+  doc.querySelectorAll('form').forEach(form => {
+    const actionAttr = form.getAttribute('action');
+    const absolute = resolveAbsoluteUrl(actionAttr || baseUrl, baseUrl) || baseUrl;
+    form.setAttribute('data-proxy-action', absolute);
+    const method = (form.getAttribute('method') || 'GET').toUpperCase();
+    form.setAttribute('data-proxy-method', method);
+  });
+
+  injectControllerScript(doc, frameId);
+
+  if (!doc.head.querySelector('meta[charset]')) {
+    const meta = doc.createElement('meta');
+    meta.setAttribute('charset', 'utf-8');
+    doc.head.insertBefore(meta, doc.head.firstChild);
+  }
+
+  const title = doc.querySelector('title')?.textContent ?? undefined;
+  const serialized = '<!DOCTYPE html>\n' + doc.documentElement.outerHTML;
+  return { html: serialized, title };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -103,3 +103,11 @@ body { margin: 0; color: var(--text); background: var(--bg); font: 14px/1.4 syst
 
 .cookies { color: var(--muted); font-size: 12px; }
 
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 15px;
+}
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,7 +54,7 @@ body { margin: 0; color: var(--text); background: var(--bg); font: 14px/1.4 syst
 .main {
   grid-area: main;
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto 1fr;
   height: 100%;
 }
 
@@ -63,15 +63,42 @@ body { margin: 0; color: var(--text); background: var(--bg); font: 14px/1.4 syst
 .btn { padding: 10px 12px; border: 1px solid var(--brand); background: var(--brand); color: #fff; border-radius: 10px; cursor: pointer; }
 .btn.secondary { background: #fff; color: var(--brand); border-color: var(--brand); }
 
-.viewer { display: grid; grid-template-columns: 1fr; overflow: hidden; }
+.viewer { display: flex; flex-direction: column; overflow: hidden; }
 .doc {
-  padding: 0; overflow: auto; height: 100%;
+  padding: 0;
+  overflow: auto;
+  flex: 1;
+  background: #fff;
+  border-bottom: 1px solid var(--border);
 }
 .doc pre { margin: 0; padding: 16px; }
 .doc iframe { width: 100%; height: 100%; border: 0; background: #fff; }
 
-.footer { border-top: 1px solid var(--border); padding: 10px 12px; display: flex; gap: 10px; align-items: center; }
-.footer input[type="text"] { flex: 1; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; }
+.loading { padding: 24px; text-align: center; color: var(--muted); font-size: 15px; }
+.error { color: #b91c1c; }
+.statusbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #fafafa;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--muted);
+}
+.statusbar span { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.statusbar .notice { color: #b45309; font-weight: 600; }
+
+.cookie-panel {
+  padding: 12px 16px;
+  background: #fff;
+  border-top: 1px solid var(--border);
+  max-height: 160px;
+  overflow: auto;
+}
+.cookie-title { font-weight: 600; margin-bottom: 8px; }
+.cookie-panel ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+
 .chip { display: inline-flex; align-items: center; background: var(--chip); color: var(--brand-600); border-radius: 999px; padding: 2px 8px; font-size: 12px; }
 
 .cookies { color: var(--muted); font-size: 12px; }

--- a/src/sw/proxy-sw.ts
+++ b/src/sw/proxy-sw.ts
@@ -32,15 +32,35 @@ function b64url(s: string) {
   return enc.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
+function fromBase64Url(value: string): string {
+  const padLength = (4 - (value.length % 4 || 4)) % 4;
+  const padded = value + '='.repeat(padLength);
+  const base64 = padded.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
+}
+
 ctx.addEventListener('fetch', (event) => {
   const req = event.request;
   const url = new URL(req.url);
   const wb = (ctx as any).__WORKER_BASE as string | undefined;
   if (!wb) return; // nothing to rewrite without base
 
-  // Only handle app-origin requests to /p and /fetch
-  if (url.origin === location.origin && (url.pathname === '/p' || url.pathname === '/fetch')) {
+  const isAppOrigin = url.origin === location.origin;
+  if (!isAppOrigin) return;
+
+  if (url.pathname === '/p' || url.pathname === '/fetch' || url.pathname === '/dispatch') {
     event.respondWith(handleProxy(req));
+    return;
+  }
+
+  if (url.pathname.startsWith('/__sandbox__/asset/')) {
+    event.respondWith(handleSandboxAsset(req));
   }
 
   async function handleProxy(origReq: Request): Promise<Response> {
@@ -62,21 +82,85 @@ ctx.addEventListener('fetch', (event) => {
     }
 
     const res = await fetch(outUrl, init);
-    // Broadcast X-Set-Cookie to all clients with sid association if present on request
-    const xsc = res.headers.get('X-Set-Cookie');
-    let sid = '';
-    if (inUrl.pathname === '/p') sid = new URLSearchParams(inUrl.search).get('sid') || '';
-    if (inUrl.pathname === '/fetch') {
-      try {
-        const body = await origReq.clone().text();
-        const parsed = JSON.parse(body);
-        sid = parsed?.sid || '';
-      } catch { /* ignore */ }
+    const sid = await extractSidFromRequest(inUrl, origReq);
+    if (sid) {
+      const header = collectXSetCookie(res.headers);
+      if (header) {
+        const all = await ctx.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+        all.forEach(c => c.postMessage({ type: 'set-cookie', sid, header }));
+      }
     }
-    if (xsc) {
-      const all = await ctx.clients.matchAll({ includeUncontrolled: true, type: 'window' });
-      all.forEach(c => c.postMessage({ type: 'set-cookie', sid, header: xsc }));
+    return res;
+  }
+
+  async function handleSandboxAsset(origReq: Request): Promise<Response> {
+    const info = decodeSandboxAssetUrl(new URL(origReq.url));
+    if (!info) {
+      return new Response('Bad sandbox asset request', { status: 400 });
+    }
+    const target = info.target;
+    const sid = info.sid;
+    const proxied = `${wb}/p?sid=${encodeURIComponent(sid)}&u=${encodeURIComponent(b64url(target))}`;
+    const init: RequestInit = {
+      method: origReq.method,
+      headers: new Headers(origReq.headers),
+      body: origReq.method !== 'GET' && origReq.method !== 'HEAD' ? await origReq.clone().arrayBuffer() : undefined,
+      mode: 'cors',
+      cache: 'no-cache',
+      redirect: 'follow',
+      credentials: 'omit'
+    };
+    const res = await fetch(proxied, init);
+    if (sid) {
+      const header = collectXSetCookie(res.headers);
+      if (header) {
+        const all = await ctx.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+        all.forEach(c => c.postMessage({ type: 'set-cookie', sid, header }));
+      }
     }
     return res;
   }
 });
+
+function collectXSetCookie(headers: Headers): string | null {
+  const collected: string[] = [];
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'x-set-cookie' && value) {
+      collected.push(value);
+    }
+  });
+  if (!collected.length) return null;
+  return collected.join(',');
+}
+
+async function extractSidFromRequest(url: URL, req: Request): Promise<string> {
+  if (url.pathname === '/p') {
+    return new URLSearchParams(url.search).get('sid') || '';
+  }
+  if (url.pathname === '/fetch' || url.pathname === '/dispatch') {
+    try {
+      const body = await req.clone().text();
+      const parsed = JSON.parse(body);
+      return parsed?.sid || '';
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+function decodeSandboxAssetUrl(url: URL): { sid: string; target: string } | null {
+  const prefix = '/__sandbox__/asset/';
+  if (!url.pathname.startsWith(prefix)) return null;
+  const remainder = url.pathname.slice(prefix.length);
+  const parts = remainder.split('/').filter(Boolean);
+  if (parts.length < 3) return null;
+  const [sidEncoded, scheme, hostEncoded, ...pathParts] = parts;
+  const sid = decodeURIComponent(sidEncoded);
+  if (scheme !== 'https') return null;
+  const host = decodeURIComponent(hostEncoded);
+  const path = pathParts.length ? `/${pathParts.map(decodeURIComponent).join('/')}` : '/';
+  const qs = url.searchParams.get('__qs');
+  const query = qs ? `?${fromBase64Url(qs)}` : '';
+  return { sid, target: `https://${host}${path}${query}` };
+}

--- a/src/sw/proxy-sw.ts
+++ b/src/sw/proxy-sw.ts
@@ -20,8 +20,10 @@ ctx.addEventListener('message', (event) => {
   if (data.type === 'warmup') {
     const wb = (ctx as any).__WORKER_BASE as string | undefined;
     if (wb) {
-      // warm a trivial GET to establish TLS/H2
-      event.waitUntil(fetch(wb + '/p?sid=_warm&u=' + encodeURIComponent(b64url('https://example.com'))).catch(() => undefined));
+      const warmUrl = wb.endsWith('/') ? wb : `${wb}/`;
+      event.waitUntil(
+        fetch(warmUrl, { method: 'GET', mode: 'no-cors', cache: 'no-store' }).catch(() => undefined)
+      );
     }
   }
 });

--- a/src/ui/ConnectorApp.tsx
+++ b/src/ui/ConnectorApp.tsx
@@ -357,7 +357,23 @@ const ConnectorApp: React.FC = () => {
                 onKeyDown={(e) => { if (e.key === 'Enter') navigateActive(urlValue); }}
               />
               <button className="btn" onClick={() => { if (urlValue) navigateActive(urlValue); }}>Go</button>
-              <button className="btn secondary" onClick={() => { if (iframeRef.current?.requestFullscreen) iframeRef.current.requestFullscreen().catch(() => undefined); }}>Full Screen</button>
+              <button
+                className="btn secondary"
+                onClick={() => {
+                  const frame = iframeRef.current;
+                  if (!frame) return;
+                  const request =
+                    frame.requestFullscreen?.bind(frame) ||
+                    (frame as any).webkitRequestFullscreen?.bind(frame) ||
+                    (frame as any).mozRequestFullScreen?.bind(frame) ||
+                    (frame as any).msRequestFullscreen?.bind(frame);
+                  if (request) {
+                    Promise.resolve(request()).catch(() => undefined);
+                  }
+                }}
+              >
+                Full Screen
+              </button>
             </div>
 
             <section className="viewer">
@@ -370,7 +386,8 @@ const ConnectorApp: React.FC = () => {
                     ref={iframeRef}
                     title="document"
                     sandbox="allow-scripts allow-forms"
-                    allow="fullscreen"
+                    allow="autoplay; fullscreen; picture-in-picture"
+                    allowFullScreen
                     html={active.document.html}
                   />
                 ) : active.document?.text ? (


### PR DESCRIPTION
## Summary
- add a sandbox HTML rewrite pipeline that proxies asset URLs and intercepts navigation within the iframe so relative resources resolve through the router
- refresh the Connector UI to manage isolated sandboxes, surface status/cookies, and request fullscreen rendering while driving navigation via postMessage events
- extend the service worker and supporting utilities to use /dispatch and proxy sandbox asset requests while capturing cookies for each session

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf8082f75083339a80673cc29bfeb6